### PR TITLE
feat: require character selection and per-character sync

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -179,6 +179,10 @@ section{ background:var(--panel); border:1px solid #202636; border-radius:var(--
   border: 1px dashed #23293a;
   opacity: 0.7;
 }
+.char-row.selected {
+  border-color: var(--accent);
+  background: #192135;
+}
 .char-row .action-buttons {
   display: flex;
   gap: 4px;

--- a/js/characters/events.js
+++ b/js/characters/events.js
@@ -13,7 +13,9 @@ function initCharacterEvents() {
     const equipped = Array(9).fill(null);
     const backpack = Array.from({length: nSlots}, () => null);
     state.chars.push({ name, str, equipped, backpack });
-    saveState();
+    const idx = state.chars.length - 1;
+    state.ui.selectedChar = idx;
+    saveState(idx);
     renderChars();
     renderCharList();
     $("#name").value = "";

--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -13,7 +13,7 @@ import { renderCharList } from './list.js';
 
 // Render characters in the center panel
 function renderChars() {
-  const wrap = $("#chars"); 
+  const wrap = $("#chars");
   if (!wrap) return;
   wrap.innerHTML = "";
 
@@ -22,16 +22,21 @@ function renderChars() {
     state.ui.hiddenChars = [];
   }
 
-  state.chars.forEach((c, ci) => {
-    // Skip rendering if character is hidden
-    if (state.ui.hiddenChars.includes(ci)) {
-      return;
-    }
-    // Initialize the equipped and backpack arrays if they don't exist
-    if (!c.equipped || !Array.isArray(c.equipped)) {
-      c.equipped = Array(9).fill(null);
-    }
-    
+  const ci = state.ui.selectedChar;
+  const c = state.chars[ci];
+  if (ci === null || c === undefined || state.ui.hiddenChars.includes(ci)) {
+    const p = document.createElement("div");
+    p.className = "small";
+    p.textContent = "Select a character from the list to view.";
+    wrap.appendChild(p);
+    return;
+  }
+
+  // Initialize the equipped and backpack arrays if they don't exist
+  if (!c.equipped || !Array.isArray(c.equipped)) {
+    c.equipped = Array(9).fill(null);
+  }
+
     const backpackSlots = slotsFromSTR(c.str);
     if (!c.backpack || !Array.isArray(c.backpack)) {
       // If migrating from old format, transfer items to backpack
@@ -47,8 +52,8 @@ function renderChars() {
     if (c.backpack.length !== backpackSlots) {
       const old = c.backpack.slice(0, backpackSlots);
       while (old.length < backpackSlots) old.push(null);
-      c.backpack = old; 
-      saveState();
+      c.backpack = old;
+      saveState(ci);
     }
 
     // FIXED: Ensure equipped array is ALWAYS exactly 9 slots regardless of STR
@@ -58,7 +63,7 @@ function renderChars() {
       const old = c.equipped.slice(0, Math.min(c.equipped.length, 9));
       while (old.length < 9) old.push(null);
       c.equipped = old;
-      saveState();
+      saveState(ci);
     }
     
     // Check for sacks in equipped section
@@ -91,14 +96,14 @@ function renderChars() {
       const old = c.largeSack.slice(0, backpackSlots);
       while (old.length < backpackSlots) old.push(null);
       c.largeSack = old;
-      saveState();
+      saveState(ci);
     }
     
     if (hasSmallSack && c.smallSack.length !== 9) {
       const old = c.smallSack.slice(0, 9);
       while (old.length < 9) old.push(null);
       c.smallSack = old;
-      saveState();
+      saveState(ci);
     }
 
     // Count occupied slots in backpack and large sack (if equipped)
@@ -358,14 +363,13 @@ function renderChars() {
           state.ui.smallSackCollapsed[charIndex] = !state.ui.smallSackCollapsed[charIndex];
         }
         
-        saveState();
+        saveState(ci);
         renderChars();
       });
     });
     
     charEl.appendChild(inv);
   wrap.appendChild(charEl);
-  });
 }
 
 export { renderChars };

--- a/js/characters/slot.js
+++ b/js/characters/slot.js
@@ -61,7 +61,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       enableWrites(); // Enable writes on item edit
       // Create a new single-slot item with "New Item" name
       slotsArray[si] = { name: "New Item", slots: 1, head: true };
-      saveState();
+      saveState(ci);
       renderChars();
       renderCharList();
       
@@ -85,7 +85,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     // Initialize filledSubSlots if it doesn't exist
     if (hasSubSlots && slotObj.filledSubSlots === undefined) {
       slotObj.filledSubSlots = maxSubSlots; // Start with all sub-slots filled
-      saveState();
+      saveState(ci);
     }
     
     let slotContent = `
@@ -142,7 +142,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
             }
           }
         }
-        saveState();
+        saveState(ci);
       }
       
       // Initialize expanded state if it doesn't exist
@@ -270,7 +270,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       enableWrites(); // Enable writes on item drop
       const targetArray = state.chars[tci][targetSection];
       tryPlaceMulti(tci, tsi, src.name, Math.max(1, Number(src.slots || 1)), targetArray, targetSection, src);
-      saveState(); 
+      saveState(ci);
       renderChars(); 
       renderCharList();
     }
@@ -281,7 +281,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       const sourceArray = state.chars[fromChar][sourceSection];
       const targetArray = state.chars[tci][targetSection];
       moveMulti(fromChar, headIndex, tci, tsi, length, sourceArray, targetArray, sourceSection, targetSection);
-      saveState(); 
+      saveState(ci);
       renderChars(); 
       renderCharList();
     }
@@ -311,7 +311,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     slotsArray[si] = { name, slots: cur.slots, head: true };
     for (let k = 1; k < cur.slots; k++) slotsArray[si + k] = { link: si };
     
-    saveState(); 
+    saveState(ci);
     renderChars(); 
     renderCharList();
   });
@@ -334,7 +334,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
           slotObj.coinAmounts[type] = 0;
         });
       }
-      saveState();
+      saveState(ci);
     }
     // Toggle expanded state when clicking on the slot
     slot.addEventListener('click', (e) => {
@@ -429,7 +429,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
             input.addEventListener('change', (e) => {
               enableWrites();
               slotObj.coinAmounts[coinType] = parseInt(e.target.value) || 0;
-              saveState();
+              saveState(ci);
             });
             
             // Add elements to row
@@ -449,7 +449,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
           closeBtn.textContent = 'Close';
           closeBtn.addEventListener('click', () => {
             slotObj.expanded = false;
-            saveState();
+            saveState(ci);
             renderChars(); // Re-render to show closed state
           });
           
@@ -471,10 +471,10 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
           slot.style.border = '2px solid #69a9ff';
           
           // Save state but don't re-render
-          saveState();
+          saveState(ci);
         } else {
           // Let the regular render cycle handle collapsing
-          saveState();
+          saveState(ci);
           renderChars();
         }
       } else {
@@ -512,7 +512,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         // Update the coin amount in the state
         slotObj.coinAmounts = slotObj.coinAmounts || {};
         slotObj.coinAmounts[coinType] = value;
-        saveState();
+        saveState(ci);
         renderChars(); // Re-render to update coin limits
       });
     });
@@ -523,7 +523,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         // If click is outside the current slot
         if (!slot.contains(e.target)) {
           slotObj.expanded = false;
-          saveState();
+          saveState(ci);
           renderChars();
           document.removeEventListener('click', closeExpandedCoinPurse);
         }
@@ -558,7 +558,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       }
       
       removeMulti(ci, headIdx, slotsArray, section);
-      saveState(); 
+      saveState(ci);
       renderChars(); 
       renderCharList();
     } else if (btn.dataset.action === "edit") {
@@ -593,7 +593,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       for (let k = 1; k < cur.slots; k++) slotsArray[si + k] = { link: si };
       
-      saveState(); 
+      saveState(ci);
       renderChars(); 
       renderCharList();
     } 
@@ -612,7 +612,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
           }
         }
         
-        saveState();
+        saveState(ci);
         renderChars();
         renderCharList();
       }
@@ -624,7 +624,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       if (cur.hasSubSlots && cur.filledSubSlots < cur.maxSubSlots) {
         cur.filledSubSlots++;
-        saveState();
+        saveState(ci);
         renderChars();
         renderCharList();
       }

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -40,6 +40,7 @@ function importData() {
         // Replace current inventory and character data with imported data
         state.chars = obj.chars;
         state.items = obj.items;
+        state.chars.forEach((_, idx) => saveState(idx));
         saveState();
         
         // Update all UI components


### PR DESCRIPTION
## Summary
- require choosing a character before editing by rendering only selected character
- store each character separately in Firebase with unique ids and timestamps
- allow reorder/delete to sync individual characters and highlight selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a217d288324a3b5f8c05d83f8f5