### PR TITLE
fix character visibility and stabilize coin purse expansion

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -175,7 +175,7 @@ section{ background:var(--panel); border:1px solid #202636; border-radius:var(--
   border:1px solid #23293a; border-radius:8px; padding:8px 10px; background:#101626;
   font-size:13px; cursor:grab;
 }
-.char-row.hidden {
+.char-row.hidden-char {
   border: 1px dashed #23293a;
   opacity: 0.7;
 }

--- a/js/characters/list.js
+++ b/js/characters/list.js
@@ -28,7 +28,7 @@ function renderCharList() {
     // Add hidden class if character is hidden
     const isHidden = state.ui.hiddenChars.includes(i);
     const isSelected = state.ui.selectedChar === i;
-    row.className = `char-row${isHidden ? ' hidden' : ''}${isSelected ? ' selected' : ''}`;
+    row.className = `char-row${isHidden ? ' hidden-char' : ''}${isSelected ? ' selected' : ''}`;
     
     // Add draggable attribute to enable drag functionality
     row.draggable = true;

--- a/js/characters/slot.js
+++ b/js/characters/slot.js
@@ -132,7 +132,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         (slotObj.coinTypes || ["PP", "GP", "SP", "CP", "EP", "Gems"]).forEach(type => {
           slotObj.coinAmounts[type] = 0;
         });
-        
+
         // If the name contains a coin amount like "32gp", set the initial amount
         if (slotObj.name && slotObj.name.toLowerCase().includes('coin')) {
           const match = slotObj.name.match(/(\d+)([a-z]+)/i);
@@ -147,12 +147,11 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         }
         saveState(ci);
       }
-      
-      // Initialize expanded state if it doesn't exist
-      if (slotObj.expanded === undefined) {
-        slotObj.expanded = false;
-      }
-      
+
+      const charId = state.chars[ci]?.id || ci;
+      const purseKey = `${charId}-${section}-${si}`;
+      const expanded = !!state.ui.expandedCoinPurses[purseKey];
+
       // Calculate total coins and value
       let totalCoins = 0;
       let totalValue = 0;
@@ -208,10 +207,10 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       // Add collapsed summary or expanded coin inputs - use CSS classes instead of inline styles
       slotContent += `
-        <div class="coin-summary ${slotObj.expanded ? 'hidden' : ''}">
+        <div class="coin-summary ${expanded ? 'hidden' : ''}">
           <span>${totalCoins}/100 coins (${formattedValue})</span>
         </div>
-        <div class="coin-slots-container ${slotObj.expanded ? '' : 'hidden'}">
+        <div class="coin-slots-container ${expanded ? '' : 'hidden'}">
       `;
       
       // Create inputs for each coin type
@@ -342,150 +341,15 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     }
     // Toggle expanded state when clicking on the slot
     slot.addEventListener('click', (e) => {
-      // Enhanced debugging
-      console.log('Coin purse clicked', e.target.tagName, e.target.className);
-      console.log('Current expanded state:', slotObj.expanded);
-      
-      // Don't toggle if clicking on inputs or buttons
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'BUTTON') {
-        console.log('Ignoring click on input/button');
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'BUTTON' ||
+          e.target.closest('.btn') || e.target.closest('.slot-actions')) {
         return;
       }
-      
-      // Ensure we're not clicking on a button within the slot
-      if (e.target.closest('.btn') || e.target.closest('.slot-actions')) {
-        console.log('Ignoring click on button or slot action');
-        return;
-      }
-      
-      // Check if we're clicking on any interactive elements that should be excluded
-      const isOnInteractiveElement = 
-        e.target.tagName === 'INPUT' || 
-        e.target.tagName === 'BUTTON' || 
-        e.target.closest('.btn') !== null || 
-        e.target.closest('.slot-actions') !== null;
-      
-      // If not on an interactive element, allow the click to toggle expansion
-      if (!isOnInteractiveElement) {
-        console.log('Toggling coin purse expanded state');
-        enableWrites();
-        // Toggle expanded state but don't re-render
-        slotObj.expanded = !slotObj.expanded;
-        console.log('New expanded state:', slotObj.expanded);
-        
-        // Create the expanded coin management view directly
-        // This bypasses issues with the CSS hidden class and render cycles
-        if (slotObj.expanded) {
-          // Create the coin management interface directly
-          slot.innerHTML = '';
-          
-          // Create container div
-          const container = document.createElement('div');
-          container.style.padding = '8px';
-          
-          // Create header with item name
-          const header = document.createElement('div');
-          header.innerHTML = `<span class="item-tag">${slotObj.name}</span>`;
-          container.appendChild(header);
-          
-          // Create coin input fields
-          const coinContainer = document.createElement('div');
-          coinContainer.style.backgroundColor = '#0f1421';
-          coinContainer.style.padding = '10px';
-          coinContainer.style.borderRadius = '6px';
-          coinContainer.style.marginTop = '8px';
-          coinContainer.style.border = '1px solid #2a3042';
-          
-          // Add each coin type
-          (slotObj.coinTypes || ["PP","GP", "SP", "CP", "EP", "Gems"]).forEach(coinType => {
-            const amount = slotObj.coinAmounts[coinType] || 0;
-            const coinColor = getCoinColor(coinType);
-            
-            // Create row
-            const row = document.createElement('div');
-            row.style.display = 'flex';
-            row.style.alignItems = 'center';
-            row.style.marginBottom = '6px';
-            row.style.gap = '8px';
-            
-            // Create coin icon
-            const coinIcon = document.createElement('span');
-            coinIcon.className = 'coin-icon';
-            coinIcon.style.backgroundColor = coinColor;
-            coinIcon.textContent = coinType;
-            
-            // Create input
-            const input = document.createElement('input');
-            input.type = 'number';
-            input.className = 'coin-amount';
-            input.value = amount;
-            input.min = 0;
-            input.dataset.coinType = coinType;
-            
-            // Prevent arrow keys from changing the value
-            input.addEventListener('keydown', (e) => {
-              if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-                e.preventDefault();
-              }
-            });
-            
-            // Add event listener for input
-            input.addEventListener('change', (e) => {
-              enableWrites();
-              slotObj.coinAmounts[coinType] = parseInt(e.target.value) || 0;
-              saveState(ci);
-            });
-            
-            // Add elements to row
-            row.appendChild(coinIcon);
-            row.appendChild(input);
-            row.appendChild(document.createTextNode('/100'));
-            
-            // Add row to container
-            coinContainer.appendChild(row);
-          });
-          
-          // Add a button to close the expanded view
-          const closeBtn = document.createElement('button');
-          closeBtn.className = 'btn';
-          closeBtn.style.marginTop = '8px';
-          closeBtn.style.width = '100%';
-          closeBtn.textContent = 'Close';
-          closeBtn.addEventListener('click', () => {
-            slotObj.expanded = false;
-            saveState(ci);
-            renderChars(); // Re-render to show closed state
-          });
-          
-          // Assemble the UI
-          container.appendChild(coinContainer);
-          container.appendChild(closeBtn);
-          
-          // Add standard slot actions
-          const actions = document.createElement('span');
-          actions.className = 'slot-actions';
-          actions.innerHTML = `
-            <button class="btn" data-action="edit">Edit</button>
-            <button class="btn danger" data-action="remove">Remove</button>
-          `;
-          
-          // Add everything to the slot
-          slot.appendChild(container);
-          slot.appendChild(actions);
-          slot.style.border = '2px solid #69a9ff';
-          
-          // Save state but don't re-render
-          saveState(ci);
-        } else {
-          // Let the regular render cycle handle collapsing
-          saveState(ci);
-          renderChars();
-        }
-      } else {
-        console.log('Click not on valid coin purse element');
-      }
+      enableWrites();
+      state.ui.expandedCoinPurses[purseKey] = !state.ui.expandedCoinPurses[purseKey];
+      renderChars();
     });
-    
+
     // Add event listeners to prevent arrow keys on coin inputs
     slot.querySelectorAll('.coin-amount').forEach(input => {
       // Prevent up/down arrow keys from changing the value
@@ -520,14 +384,12 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         renderChars(); // Re-render to update coin limits
       });
     });
-    
+
     // Close expanded coin purse when clicking outside
-    if (slotObj.expanded) {
+    if (expanded) {
       document.addEventListener('click', function closeExpandedCoinPurse(e) {
-        // If click is outside the current slot
         if (!slot.contains(e.target)) {
-          slotObj.expanded = false;
-          saveState(ci);
+          state.ui.expandedCoinPurses[purseKey] = false;
           renderChars();
           document.removeEventListener('click', closeExpandedCoinPurse);
         }

--- a/js/state.js
+++ b/js/state.js
@@ -16,7 +16,8 @@ const state = {
     leftCollapsed: false,
     rightCollapsed: false,
     hiddenChars: [],       // Track which characters are hidden
-    selectedChar: null     // Currently selected character index
+    selectedChar: null,    // Currently selected character index
+    expandedCoinPurses: {} // Track expanded coin purses locally
   },
   readOnlyMode: true      // Start in read-only mode by default
 };
@@ -34,6 +35,10 @@ function loadLocalState() {
 const localState = loadLocalState();
 if (localState) {
   Object.assign(state, localState);
+}
+// Ensure expandedCoinPurses exists after loading
+if (!state.ui.expandedCoinPurses) {
+  state.ui.expandedCoinPurses = {};
 }
 
 // Flag to prevent sync loops
@@ -65,11 +70,25 @@ function saveState(charIndex) {
     get(charRef).then((snap) => {
       const data = snap.val();
       if (data && data.lastUpdated && data.lastUpdated !== c.lastUpdated) {
-        alert(`${c.name} has newer data on the server. Please reload before saving.`);
+        console.warn(`${c.name} has newer data on the server. Please reload before saving.`);
         return;
       }
+      // Create a sanitized copy without local UI-only properties
+      const sanitized = JSON.parse(JSON.stringify(c));
+      ['equipped', 'backpack', 'largeSack', 'smallSack'].forEach(sec => {
+        if (Array.isArray(sanitized[sec])) {
+          sanitized[sec] = sanitized[sec].map(slot => {
+            if (slot && typeof slot === 'object') {
+              const { expanded, ...rest } = slot;
+              return rest;
+            }
+            return slot;
+          });
+        }
+      });
+
       const payload = {
-        ...c,
+        ...sanitized,
         order: charIndex,
         lastUpdated: Date.now(),
         lastUpdatedBy: sessionId


### PR DESCRIPTION
## Summary
- keep hidden characters in the list so they can be toggled back on
- tone down reload warning by logging to the console instead of blocking
- remember coin purse expansion locally so syncs don't collapse it

## Testing
- `node --check js/characters/list.js`
- `node --check js/state.js`
- `node --check js/characters/slot.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e966bef7483248330a9ff09497717