### PR TITLE
refactor item storage to id-keyed objects

### DIFF
--- a/js/characters/slot.js
+++ b/js/characters/slot.js
@@ -225,7 +225,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     const targetSection = section; // equipped or backpack
 
     if (payload.type === "lib") {
-      const src = state.items[payload.idx]; 
+      const src = state.items[payload.id];
       if (!src) return;
       enableWrites(); // Enable writes on item drop
       const targetArray = state.chars[tci][targetSection];

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -35,11 +35,16 @@ function importData() {
     fr.onload = () => {
       try {
         const obj = JSON.parse(fr.result);
-        if (!obj || typeof obj !== "object" || !Array.isArray(obj.items) || !Array.isArray(obj.chars)) throw 0;
-        
+        if (!obj || typeof obj !== "object" || typeof obj.items !== 'object' || !Array.isArray(obj.chars)) throw 0;
+
         // Replace current inventory and character data with imported data
         state.chars = obj.chars;
-        state.items = obj.items;
+        state.items = obj.items || {};
+
+        // Persist items individually
+        for (const [id, item] of Object.entries(state.items)) {
+          saveState(`items/${id}`, item);
+        }
         saveState();
         
         // Update all UI components


### PR DESCRIPTION
## Summary
- store library items in an object keyed by unique Firebase IDs
- persist item changes by writing only the affected `items/<id>` path
- update inventory UI and import/export to handle id-based items

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689f390827ac832498a32ccbf03dd995