### PR TITLE
feat: debounce note inputs

### DIFF
--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -5,7 +5,8 @@ import {
   slotsFromSTR,
   speedFactorFromEmpty,
   fmtSpeed,
-  slowdownLabel
+  slowdownLabel,
+  debounce
 } from '../helpers.js';
 
 import { createSlot } from './slot.js';
@@ -358,11 +359,14 @@ function renderChars() {
     notesArea.className = "notes-textarea";
     notesArea.placeholder = "Add notes...";
     notesArea.value = c.notes;
-    notesArea.addEventListener("input", () => {
+    // Debounce note saving to avoid excessive state writes while typing
+    const debouncedSaveNotes = debounce(() => {
       enableWrites();
       c.notes = notesArea.value;
       saveState();
-    });
+    }, 400);
+
+    notesArea.addEventListener("input", debouncedSaveNotes);
 
     notesSection.appendChild(notesArea);
     inv.appendChild(notesSection);

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,6 +1,15 @@
 /* ===== Helpers & Rules ===== */
 const $ = s => document.querySelector(s);
 
+// Simple debounce utility to limit how often a function runs
+function debounce(fn, delay = 300) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delay);
+  };
+}
+
 function slotsFromSTR(str){
   const s = Math.floor(Number(str) || 0);
   if (s >= 18) return 19;
@@ -200,6 +209,7 @@ function moveMulti(fromChar, headIndex, toChar, toStart, len, fromCharSlots, toC
 
 export {
   $,
+  debounce,
   slotsFromSTR,
   speedFactorFromEmpty,
   fmtSpeed,

--- a/js/items.js
+++ b/js/items.js
@@ -1,6 +1,6 @@
 /* ===== Items Management ===== */
 import { state, saveState, enableWrites } from './state.js';
-import { $ } from './helpers.js';
+import { $, debounce } from './helpers.js';
 import { 
   database, 
   ref, 
@@ -237,6 +237,18 @@ function renderItems() {
       alert("Please enter a valid item name");
     }
   });
+
+  // Debounced saving for notes field in create item form
+  const createNotesInput = $("#itemNotes");
+  if (createNotesInput) {
+    const debouncedCreateNotes = debounce(() => {
+      enableWrites();
+      if (!state.ui) state.ui = {};
+      state.ui.tempItemNotes = createNotesInput.value;
+      saveState();
+    }, 400);
+    createNotesInput.addEventListener("input", debouncedCreateNotes);
+  }
   
   // Toggle sub-slot options visibility based on checkbox state
   $("#itemHasSubSlots")?.addEventListener("change", () => {
@@ -305,6 +317,19 @@ function renderItems() {
       alert("Please enter a valid item name");
     }
   });
+
+  // Debounced saving for notes field in edit item form
+  const editNotesInput = $("#editItemNotes");
+  if (editNotesInput) {
+    const debouncedEditNotes = debounce(() => {
+      enableWrites();
+      const id = $("#editItemId")?.value || "";
+      if (!id || !state.items[id]) return;
+      state.items[id].notes = editNotesInput.value;
+      saveState(`items/${id}/notes`, state.items[id].notes);
+    }, 400);
+    editNotesInput.addEventListener("input", debouncedEditNotes);
+  }
   
   // Toggle sub-slot options visibility based on checkbox state
   $("#editItemHasSubSlots")?.addEventListener("change", () => {
@@ -412,9 +437,14 @@ function toggleCreateItemForm() {
       document.querySelectorAll(".sub-slot-options").forEach(el => {
         el.classList.add("hidden");
       });
+      if (!state.ui) state.ui = {};
+      state.ui.tempItemNotes = "";
       $("#itemName").focus();
+    } else {
+      // Clear any stored draft when hiding
+      if (state.ui) state.ui.tempItemNotes = "";
     }
-    
+
     // Hide edit form if open
     const editForm = $("#editItemForm");
     if (editForm && !editForm.classList.contains("hidden")) {


### PR DESCRIPTION
## Summary
- add reusable debounce utility
- debounce character notes input to reduce save chatter
- debounce notes fields in create and edit item forms

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4facf8d88324b7e0c59cde3420e9