### PR TITLE
Add Firebase authentication and user-scoped data paths

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "inventory": {
+      "$uid": {
+        ".read": "auth != null && auth.uid === $uid",
+        ".write": "auth != null && auth.uid === $uid"
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -49,6 +49,12 @@
     background-color: #2196F3;
     color: white;
   }
+
+  .auth-controls {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
 </style>
 </head>
 <body>
@@ -57,6 +63,10 @@
 <div id="read-only-status" class="read-only">Read-Only Mode</div>
 <header>
   <h1>Inventory Tracker</h1>
+  <div class="auth-controls">
+    <button id="loginBtn">Login</button>
+    <button id="logoutBtn" style="display:none">Logout</button>
+  </div>
   <div class="sub">Slots‑only slowdown from 120' base → 90'/60'/30' when empty slots drop below 6 / 4 / 2.</div>
 </header>
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,44 @@
+/* ===== Firebase Authentication ===== */
+import {
+  auth,
+  onAuthStateChanged,
+  signInWithPopup,
+  GoogleAuthProvider,
+  signOut
+} from './firebase-config.js';
+import { state, setUser, updateReadOnlyIndicator } from './state.js';
+import { loadItemsFromFile } from './items.js';
+
+function initAuth() {
+  const loginBtn = document.getElementById('loginBtn');
+  const logoutBtn = document.getElementById('logoutBtn');
+  const provider = new GoogleAuthProvider();
+
+  loginBtn?.addEventListener('click', () => {
+    signInWithPopup(auth, provider).catch(err => console.error('Login failed', err));
+  });
+
+  logoutBtn?.addEventListener('click', () => {
+    signOut(auth).catch(err => console.error('Logout failed', err));
+  });
+
+  onAuthStateChanged(auth, (user) => {
+    if (user) {
+      setUser(user.uid);
+      state.readOnlyMode = false;
+      updateReadOnlyIndicator();
+      loadItemsFromFile();
+      if (loginBtn) loginBtn.style.display = 'none';
+      if (logoutBtn) logoutBtn.style.display = 'inline-block';
+    } else {
+      setUser(null);
+      state.readOnlyMode = true;
+      updateReadOnlyIndicator();
+      loadItemsFromFile();
+      if (logoutBtn) logoutBtn.style.display = 'none';
+      if (loginBtn) loginBtn.style.display = 'inline-block';
+    }
+  });
+}
+
+export { initAuth };

--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -363,7 +363,7 @@ function renderChars() {
 
     const debouncedSaveNotes = debounce(() => {
       enableWrites();
-      saveState(`inventory/chars/${ci}/notes`, c.notes);
+      saveState(`chars/${ci}/notes`, c.notes);
     }, 400);
 
     notesArea.addEventListener("input", () => {

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -2,16 +2,23 @@
 
 // Import Firebase modules
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-app.js';
-import { 
-  getDatabase, 
-  ref, 
-  onValue, 
-  set, 
+import {
+  getDatabase,
+  ref,
+  onValue,
+  set,
   update,
   push,
   get,
   child
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithPopup,
+  GoogleAuthProvider,
+  signOut
+} from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-auth.js';
 
 // Firebase configuration loaded from environment variables
 const firebaseConfig = {
@@ -27,6 +34,7 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const database = getDatabase(app);
+const auth = getAuth(app);
 
 // Generate a unique ID for this user's session if they don't have one
 let sessionId = localStorage.getItem("inventory_session_id");
@@ -38,6 +46,7 @@ if (!sessionId) {
 // Export Firebase modules and initialized instances
 export {
   database,
+  auth,
   ref,
   onValue,
   set,
@@ -45,5 +54,9 @@ export {
   push,
   get,
   child,
-  sessionId
+  sessionId,
+  onAuthStateChanged,
+  signInWithPopup,
+  GoogleAuthProvider,
+  signOut
 };

--- a/js/main.js
+++ b/js/main.js
@@ -1,29 +1,30 @@
 /* ===== Main Application Entry Point ===== */
-import { state, initFirebaseSync, updateReadOnlyIndicator } from './state.js';
+import { state, updateReadOnlyIndicator } from './state.js';
 import { applyCollapses, initUIControls } from './ui.js';
 import { loadItemsFromFile, renderItems, initItemEvents } from './items.js';
 import { renderChars, renderCharList, initCharacterEvents } from './characters.js';
 import { initExportImportEvents } from './export-import.js';
+import { initAuth } from './auth.js';
 
 // Initialize the application
 function initApp() {
+  // Initialize authentication
+  initAuth();
+
   // Apply UI states
   applyCollapses();
-  
+
   // Initialize all event listeners
   initUIControls();
   initItemEvents();
   initCharacterEvents();
   initExportImportEvents();
-  
+
   // Initial render
   renderCharList();
   renderChars();
   loadItemsFromFile(); // async; will call renderItems() when done
-  
-  // Initialize Firebase real-time sync
-  initFirebaseSync();
-  
+
   // Initialize read-only indicator
   updateReadOnlyIndicator();
   


### PR DESCRIPTION
## Summary
- integrate Firebase Authentication and expose login/logout controls
- scope Realtime Database data under each user's UID and restrict rules accordingly
- reload data and toggle read-only mode based on authentication state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a3e412d08324b1328d87de4dd350