### PR TITLE
Add cache-control meta tag and versioned asset URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
 <title>Inventory Tracker — External Items, Multi‑slot, Column View</title>
-<link rel="stylesheet" href="css/styles.css">
+<link rel="stylesheet" href="css/styles.css?v=1.0.1">
 <style>
   /* Notification styles */
   /* Sync notification styles removed */
@@ -122,9 +123,9 @@
 </main>
 
 <!-- Load environment variables -->
-<script src="env.js"></script>
+<script src="env.js?v=1.0.1"></script>
 <!-- Load the application code -->
-<script type="module" src="js/main.js"></script>
+<script type="module" src="js/main.js?v=1.0.1"></script>
 
 <!-- Notification Handler -->
 <script type="module">


### PR DESCRIPTION
## Summary
- prevent client-side caching with a `Cache-Control` meta tag
- append version query strings to CSS and JS references for easier cache busting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65c817e7083249f90825ff53bc945