### PR TITLE
Use server timestamps for Firebase sync

### DIFF
--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -2,15 +2,16 @@
 
 // Import Firebase modules
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-app.js';
-import { 
-  getDatabase, 
-  ref, 
-  onValue, 
-  set, 
+import {
+  getDatabase,
+  ref,
+  onValue,
+  set,
   update,
   push,
   get,
-  child
+  child,
+  serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
 
 // Firebase configuration loaded from environment variables
@@ -45,5 +46,6 @@ export {
   push,
   get,
   child,
+  serverTimestamp,
   sessionId
 };


### PR DESCRIPTION
## Summary
- Import and export `serverTimestamp` in Firebase config
- Use `serverTimestamp()` when persisting inventory state
- Track and compare Firebase timestamps to avoid processing stale updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65c7fdf90832497ab2311376e58c5