### PR TITLE
Track update timestamps and resolve concurrent writes

### DIFF
--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -2,15 +2,16 @@
 
 // Import Firebase modules
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-app.js';
-import { 
-  getDatabase, 
-  ref, 
-  onValue, 
-  set, 
-  update,
+import {
+  getDatabase,
+  ref,
+  onValue,
+  set,
   push,
   get,
-  child
+  child,
+  runTransaction,
+  serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
 
 // Firebase configuration loaded from environment variables
@@ -41,9 +42,10 @@ export {
   ref,
   onValue,
   set,
-  update,
   push,
   get,
   child,
+  runTransaction,
+  serverTimestamp,
   sessionId
 };

--- a/js/state.js
+++ b/js/state.js
@@ -1,10 +1,13 @@
 /* ===== State & Persistence ===== */
-import { 
-  database, 
-  ref, 
-  onValue, 
-  set, 
-  update,
+import {
+  database,
+  ref,
+  onValue,
+  set,
+  get,
+  child,
+  runTransaction,
+  serverTimestamp,
   sessionId
 } from './firebase-config.js';
 
@@ -12,12 +15,13 @@ import {
 const state = {
   items: {},              // loaded from items.json
   chars: [],
-  ui: { 
-    leftCollapsed: false, 
+  ui: {
+    leftCollapsed: false,
     rightCollapsed: false,
     hiddenChars: []       // Track which characters are hidden
   },
-  readOnlyMode: true      // Start in read-only mode by default
+  readOnlyMode: true,     // Start in read-only mode by default
+  lastUpdated: 0
 };
 
 // Load state from local storage initially (for quick startup)
@@ -43,8 +47,20 @@ if (localState) {
 // Flag to prevent sync loops
 let isSyncing = false;
 
+// Helper to set a nested value in an object using a slash-delimited path
+function setByPath(obj, path, value) {
+  const parts = path.split('/');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i];
+    if (!(p in cur)) cur[p] = {};
+    cur = cur[p];
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
 // Save state to local storage and Firebase
-function saveState(path = null, value) {
+async function saveState(path = null, value) {
   // Always save to localStorage for quick loading next time
   localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
 
@@ -52,17 +68,50 @@ function saveState(path = null, value) {
   // or if we're in read-only mode and haven't had user interaction yet
   if (isSyncing || state.readOnlyMode) return;
 
-  if (path) {
-    set(ref(database, path), value);
+  // Paths outside inventory can be written directly without timestamp checks
+  if (path && !path.startsWith('inventory')) {
+    await set(ref(database, path), value);
     return;
   }
 
-  // Save character state
-  set(ref(database, 'inventory'), {
-    chars: state.chars,
-    lastUpdated: Date.now(),
-    lastUpdatedBy: sessionId
-  });
+  const inventoryRef = ref(database, 'inventory');
+
+  // Fetch remote lastUpdated for comparison
+  try {
+    const remoteSnap = await get(child(inventoryRef, 'lastUpdated'));
+    const remoteLastUpdated = remoteSnap.exists() ? remoteSnap.val() : 0;
+    if (remoteLastUpdated > state.lastUpdated) {
+      console.warn('Remote state is newer; skipping save.');
+      return;
+    }
+  } catch (err) {
+    console.warn('Could not check remote lastUpdated:', err);
+  }
+
+  // Use transaction to handle concurrent writes with timestamp comparison
+  try {
+    const result = await runTransaction(inventoryRef, (current) => {
+      if (current && current.lastUpdated > state.lastUpdated) {
+        return; // Abort - remote is newer
+      }
+      const updated = current || {};
+      if (path) {
+        const rel = path.slice('inventory/'.length);
+        setByPath(updated, rel, value);
+      } else {
+        updated.chars = state.chars;
+      }
+      updated.lastUpdated = serverTimestamp();
+      updated.lastUpdatedBy = sessionId;
+      return updated;
+    });
+    if (result.committed) {
+      state.lastUpdated = result.snapshot.val().lastUpdated || state.lastUpdated;
+      localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
+    }
+  } catch (err) {
+    console.error('Failed to save state:', err);
+  }
 }
 
 // Enable writes after user interaction with inventory or characters
@@ -97,10 +146,13 @@ function initFirebaseSync() {
   const inventoryRef = ref(database, 'inventory');
   onValue(inventoryRef, (snapshot) => {
     const data = snapshot.val();
-    
+
     // Ignore null data (first initialization)
     if (!data) return;
-    
+
+    // Store remote last updated timestamp
+    state.lastUpdated = data.lastUpdated || 0;
+
     // Skip if this update was triggered by the current session
     if (data.lastUpdatedBy === sessionId) return;
     


### PR DESCRIPTION
## Summary
- track last update timestamp in client state and Firebase
- compare timestamps before saving to avoid overwriting newer data
- export Firebase utilities for server timestamps and transactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65c75b86483248ddcc3a3749d2338