### PR TITLE
Add stricter cache control and bump asset versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
 <title>Inventory Tracker — External Items, Multi‑slot, Column View</title>
-<link rel="stylesheet" href="css/styles.css?v=1.0.1">
+<link rel="stylesheet" href="css/styles.css?v=1.0.2">
 <style>
   /* Notification styles */
   /* Sync notification styles removed */
@@ -123,9 +123,9 @@
 </main>
 
 <!-- Load environment variables -->
-<script src="env.js?v=1.0.1"></script>
+<script src="env.js?v=1.0.2"></script>
 <!-- Load the application code -->
-<script type="module" src="js/main.js?v=1.0.1"></script>
+<script type="module" src="js/main.js?v=1.0.2"></script>
 
 <!-- Notification Handler -->
 <script type="module">


### PR DESCRIPTION
## Summary
- prevent stale cache with no-cache and no-store meta directive
- version CSS and script assets with updated query strings for cache busting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6623b4c948324967b3d66354ac638