### PR TITLE
Add inventory snapshot history and restore helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ The testing guide provides buttons to help you test specific features, such as:
 - Testing offline mode functionality
 - Verifying server setup
 
+## Backup and Restore
+
+Every time the inventory is saved, a snapshot of the current character data is stored in the `inventory/history` path of the Firebase database along with a timestamp and session identifier. These snapshots allow you to roll back to an earlier state if needed.
+
+To work with history snapshots in the browser console:
+
+```javascript
+import { fetchHistory, restoreSnapshot } from './js/history.js';
+
+// List available snapshots
+fetchHistory().then(console.log);
+
+// Restore a snapshot by its key
+restoreSnapshot('<snapshotKey>');
+```
+
+Restoring will update local storage and sync the chosen snapshot back to all connected clients.
+
 ## Firebase Setup Instructions
 
 To enable real-time syncing across users, follow these steps to set up Firebase:

--- a/js/history.js
+++ b/js/history.js
@@ -1,0 +1,29 @@
+/* ===== Inventory History Utilities ===== */
+import {
+  database,
+  ref,
+  get
+} from './firebase-config.js';
+import { state, saveState } from './state.js';
+
+// Fetch all saved history snapshots
+async function fetchHistory() {
+  const snapshot = await get(ref(database, 'inventory/history'));
+  return snapshot.val() || {};
+}
+
+// Restore a snapshot by its key
+async function restoreSnapshot(key) {
+  const snapshot = await get(ref(database, `inventory/history/${key}`));
+  const data = snapshot.val();
+  if (!data) return null;
+
+  state.chars = data.chars || [];
+  saveState();
+  return data;
+}
+
+export {
+  fetchHistory,
+  restoreSnapshot
+};

--- a/js/state.js
+++ b/js/state.js
@@ -5,6 +5,7 @@ import {
   onValue,
   set,
   update,
+  push,
   serverTimestamp,
   sessionId
 } from './firebase-config.js';
@@ -60,6 +61,13 @@ function saveState(path = null, value) {
     set(ref(database, path), value);
     return;
   }
+
+  // Backup current state before saving
+  push(ref(database, 'inventory/history'), {
+    chars: state.chars,
+    timestamp: serverTimestamp(),
+    sessionId
+  });
 
   // Save character state
   set(ref(database, 'inventory'), {


### PR DESCRIPTION
## Summary
- Save a snapshot of the current character state to `inventory/history` before each inventory write
- Provide utilities to fetch and restore snapshots
- Document backup and restore workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a667b15b888324bf105fb5747df744