### PR TITLE
Use transactions when saving inventory

### DIFF
--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -11,7 +11,8 @@ import {
   push,
   get,
   child,
-  serverTimestamp
+  serverTimestamp,
+  runTransaction
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
 
 // Firebase configuration loaded from environment variables
@@ -47,5 +48,6 @@ export {
   get,
   child,
   serverTimestamp,
+  runTransaction,
   sessionId
 };


### PR DESCRIPTION
## Summary
- export `runTransaction` from Firebase config for transactional updates
- use `runTransaction` in `saveState` to prevent overwriting newer remote data
- reload remote state and retry when transactions fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66a348b508324b4fc00ca742edb1e