### PR TITLE
feat: sync items across sessions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 /* ===== Main Application Entry Point ===== */
 import { state, initFirebaseSync, updateReadOnlyIndicator } from './state.js';
 import { applyCollapses, initUIControls } from './ui.js';
-import { loadItems, renderItems, initItemEvents } from './items.js';
+import { loadItems, renderItems, initItemEvents, initItemSync } from './items.js';
 import { renderChars, renderCharList, initCharacterEvents } from './characters.js';
 import { initExportImportEvents } from './export-import.js';
 
@@ -20,6 +20,7 @@ function initApp() {
   renderCharList();
   renderChars();
   loadItems(); // async; will call renderItems() when done
+  initItemSync();
   
   // Initialize Firebase real-time sync
   initFirebaseSync();


### PR DESCRIPTION
## Summary
- add initItemSync listener to keep item library in sync across sessions
- log item changes to `items/history` with timestamps and session ids
- initialize item sync during app startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6776eaabc8324bc560d2a443c79a5