### PR TITLE
docs: expand database rules for items node

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,8 @@ To enable real-time syncing across users, follow these steps to set up Firebase:
 ```json
 {
   "rules": {
-    "inventory": {
-      ".read": true,
-      ".write": true
-    }
+    "inventory": { ".read": true, ".write": true },
+    "items": { ".read": true, ".write": true }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- document Realtime Database rules that grant read/write access to both `inventory` and `items` nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a681843460832495b9a3dd70773c40