### PR TITLE
Use direct Firebase calls for item CRUD

### DIFF
--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -12,7 +12,8 @@ import {
   get,
   child,
   serverTimestamp,
-  runTransaction
+  runTransaction,
+  remove
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
 
 // Firebase configuration loaded from environment variables
@@ -49,5 +50,6 @@ export {
   child,
   serverTimestamp,
   runTransaction,
+  remove,
   sessionId
 };


### PR DESCRIPTION
## Summary
- add items directly via `push` and handle push errors
- update items using `set` and delete using `remove`
- export `remove` from Firebase config

## Testing
- `node --check js/items.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a68222f46c8324ab8b09bb63969593