### PR TITLE
Prevent cross-character overwrites when updating inventory

### DIFF
--- a/js/characters/events.js
+++ b/js/characters/events.js
@@ -13,7 +13,7 @@ function initCharacterEvents() {
     const equipped = Array(9).fill(null);
     const backpack = Array.from({length: nSlots}, () => null);
     state.chars.push({ name, str, equipped, backpack, notes: "" });
-    saveState();
+    saveState('inventory/chars', state.chars);
     renderChars();
     renderCharList();
     $("#name").value = "";

--- a/js/characters/list.js
+++ b/js/characters/list.js
@@ -75,7 +75,7 @@ function renderCharList() {
         // Reorder the characters array
         const [movedChar] = state.chars.splice(fromIndex, 1);
         state.chars.splice(toIndex, 0, movedChar);
-        saveState();
+        saveState('inventory/chars', state.chars);
         renderChars();
         renderCharList();
       }
@@ -90,12 +90,12 @@ function renderCharList() {
         if (action === "delete") {
           if (confirm(`Delete ${state.chars[idx].name}?`)) {
             enableWrites();
-            state.chars.splice(idx, 1); 
-            saveState(); 
-            renderChars(); 
+            state.chars.splice(idx, 1);
+            saveState('inventory/chars', state.chars);
+            renderChars();
             renderCharList();
           }
-        } 
+        }
         else if (action === "toggle-visibility") {
           enableWrites();
           const hiddenIndex = state.ui.hiddenChars.indexOf(idx);
@@ -106,8 +106,8 @@ function renderCharList() {
             // Character is currently visible, hide it
             state.ui.hiddenChars.push(idx);
           }
-          saveState();
-          renderChars(); 
+          saveState('ui/hiddenChars', state.ui.hiddenChars);
+          renderChars();
           renderCharList();
         }
       });

--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -47,8 +47,8 @@ function renderChars() {
     if (c.backpack.length !== backpackSlots) {
       const old = c.backpack.slice(0, backpackSlots);
       while (old.length < backpackSlots) old.push(null);
-      c.backpack = old; 
-      saveState();
+      c.backpack = old;
+      saveState(`inventory/chars/${ci}/backpack`, c.backpack);
     }
 
     // FIXED: Ensure equipped array is ALWAYS exactly 9 slots regardless of STR
@@ -58,13 +58,13 @@ function renderChars() {
       const old = c.equipped.slice(0, Math.min(c.equipped.length, 9));
       while (old.length < 9) old.push(null);
       c.equipped = old;
-      saveState();
+      saveState(`inventory/chars/${ci}/equipped`, c.equipped);
     }
     
     // Initialize notes field if missing
     if (typeof c.notes !== "string") {
       c.notes = "";
-      saveState();
+      saveState(`inventory/chars/${ci}/notes`, c.notes);
     }
 
     // Check for sacks in equipped section
@@ -97,14 +97,14 @@ function renderChars() {
       const old = c.largeSack.slice(0, backpackSlots);
       while (old.length < backpackSlots) old.push(null);
       c.largeSack = old;
-      saveState();
+      saveState(`inventory/chars/${ci}/largeSack`, c.largeSack);
     }
     
     if (hasSmallSack && c.smallSack.length !== 9) {
       const old = c.smallSack.slice(0, 9);
       while (old.length < 9) old.push(null);
       c.smallSack = old;
-      saveState();
+      saveState(`inventory/chars/${ci}/smallSack`, c.smallSack);
     }
 
     // Count occupied slots in backpack and large sack (if equipped)
@@ -398,7 +398,7 @@ function renderChars() {
           state.ui.smallSackCollapsed[charIndex] = !state.ui.smallSackCollapsed[charIndex];
         }
         
-        saveState();
+        saveState('ui', state.ui);
         renderChars();
       });
     });

--- a/js/characters/slot.js
+++ b/js/characters/slot.js
@@ -63,7 +63,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       enableWrites(); // Enable writes on item edit
       // Create a new single-slot item with "New Item" name
       slotsArray[si] = { name: "New Item", slots: 1, head: true };
-      saveState();
+      saveState(`inventory/chars/${ci}`, state.chars[ci]);
       renderChars();
       renderCharList();
       
@@ -87,7 +87,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     // Initialize filledSubSlots if it doesn't exist
     if (hasSubSlots && slotObj.filledSubSlots === undefined) {
       slotObj.filledSubSlots = maxSubSlots; // Start with all sub-slots filled
-      saveState();
+      saveState(`inventory/chars/${ci}`, state.chars[ci]);
     }
     
     let slotContent = `
@@ -144,7 +144,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
             }
           }
         }
-        saveState();
+        saveState(`inventory/chars/${ci}`, state.chars[ci]);
       }
       // Determine if this coin purse is currently expanded (client-side only)
       const purseKey = `${ci}-${section}-${si}`;
@@ -230,8 +230,8 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       enableWrites(); // Enable writes on item drop
       const targetArray = state.chars[tci][targetSection];
       tryPlaceMulti(tci, tsi, src.name, Math.max(1, Number(src.slots || 1)), targetArray, targetSection, src);
-      saveState(); 
-      renderChars(); 
+      saveState(`inventory/chars/${tci}`, state.chars[tci]);
+      renderChars();
       renderCharList();
     }
     else if (payload.type === "slotHead") {
@@ -241,8 +241,11 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       const sourceArray = state.chars[fromChar][sourceSection];
       const targetArray = state.chars[tci][targetSection];
       moveMulti(fromChar, headIndex, tci, tsi, length, sourceArray, targetArray, sourceSection, targetSection);
-      saveState(); 
-      renderChars(); 
+      saveState(`inventory/chars/${fromChar}`, state.chars[fromChar]);
+      if (fromChar !== tci) {
+        saveState(`inventory/chars/${tci}`, state.chars[tci]);
+      }
+      renderChars();
       renderCharList();
     }
   });
@@ -271,7 +274,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
     slotsArray[si] = { name, slots: cur.slots, head: true };
     for (let k = 1; k < cur.slots; k++) slotsArray[si + k] = { link: si };
     
-    saveState(); 
+    saveState(`inventory/chars/${ci}`, state.chars[ci]);
     renderChars(); 
     renderCharList();
   });
@@ -285,7 +288,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
   // Add event listener for coin amount updates
   if (isHead && (slotObj.hasCoinSlots || (slotObj.name && slotObj.name.toLowerCase().includes('coin')))) {
     // Ensure it has proper coin purse properties
-    if (!slotObj.hasCoinSlots) {
+      if (!slotObj.hasCoinSlots) {
       slotObj.hasCoinSlots = true;
       slotObj.coinTypes = ["PP","GP", "SP", "CP", "EP", "Gems"];
       if (!slotObj.coinAmounts) {
@@ -294,7 +297,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
           slotObj.coinAmounts[type] = 0;
         });
       }
-      saveState();
+      saveState(`inventory/chars/${ci}`, state.chars[ci]);
     }
     // Toggle expanded state when clicking on the slot
     slot.addEventListener('click', (e) => {
@@ -361,7 +364,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
         // Update the coin amount in the state
         slotObj.coinAmounts = slotObj.coinAmounts || {};
         slotObj.coinAmounts[coinType] = value;
-        saveState();
+        saveState(`inventory/chars/${ci}`, state.chars[ci]);
         renderChars(); // Re-render to update coin limits
       });
     });
@@ -395,8 +398,8 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       }
       
       removeMulti(ci, headIdx, slotsArray, section);
-      saveState(); 
-      renderChars(); 
+      saveState(`inventory/chars/${ci}`, state.chars[ci]);
+      renderChars();
       renderCharList();
     } else if (btn.dataset.action === "edit") {
       enableWrites(); // Enable writes on edit button
@@ -415,9 +418,9 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       const coinTypes = cur.coinTypes || ["PP","GP", "SP", "CP", "EP", "Gems"];
       const coinAmounts = cur.coinAmounts || {};
       
-      slotsArray[si] = { 
-        name, 
-        slots: cur.slots, 
+      slotsArray[si] = {
+        name,
+        slots: cur.slots,
         head: true,
         hasSubSlots,
         maxSubSlots,
@@ -430,8 +433,8 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       for (let k = 1; k < cur.slots; k++) slotsArray[si + k] = { link: si };
       
-      saveState(); 
-      renderChars(); 
+      saveState(`inventory/chars/${ci}`, state.chars[ci]);
+      renderChars();
       renderCharList();
     } 
     else if (btn.dataset.action === "use") {
@@ -441,15 +444,15 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       if (cur.hasSubSlots && cur.filledSubSlots > 0) {
         cur.filledSubSlots--;
-        
+
         // If all sub-slots are used, ask if the user wants to remove the item
         if (cur.filledSubSlots === 0) {
           if (confirm(`All ${cur.subSlotName}s have been used. Remove the item?`)) {
             removeMulti(ci, si, slotsArray, section);
           }
         }
-        
-        saveState();
+
+        saveState(`inventory/chars/${ci}`, state.chars[ci]);
         renderChars();
         renderCharList();
       }
@@ -461,7 +464,7 @@ function createSlot(slotObj, ci, si, section, slotsArray, backpackSlots, renderC
       
       if (cur.hasSubSlots && cur.filledSubSlots < cur.maxSubSlots) {
         cur.filledSubSlots++;
-        saveState();
+        saveState(`inventory/chars/${ci}`, state.chars[ci]);
         renderChars();
         renderCharList();
       }

--- a/js/export-import.js
+++ b/js/export-import.js
@@ -48,7 +48,7 @@ function importData() {
         for (const [id, item] of Object.entries(state.items)) {
           saveState(`items/${id}`, item);
         }
-        saveState();
+        saveState('inventory/chars', state.chars);
         
         // Update all UI components
         renderItems();

--- a/js/history.js
+++ b/js/history.js
@@ -19,7 +19,7 @@ async function restoreSnapshot(key) {
   if (!data) return null;
 
   state.chars = data.chars || [];
-  saveState();
+  saveState('inventory/chars', state.chars);
   return data;
 }
 

--- a/js/items.js
+++ b/js/items.js
@@ -26,11 +26,11 @@ async function loadItems() {
     } else {
       state.items = {};
     }
-    saveState();
+    saveState('items', state.items);
   } catch (err) {
     console.error("Failed to load items from Firebase:", err);
     state.items = {};
-    saveState();
+    saveState('items', state.items);
   }
 
   renderItems();
@@ -43,7 +43,7 @@ function initItemSync() {
     const data = snapshot.val() || {};
     state.items = data;
     // Save to local storage; saveState() also handles read-only safeguards
-    saveState();
+    saveState('items', state.items);
     renderItems();
   });
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -23,16 +23,16 @@ function applyCollapses() {
 // Initialize UI event listeners
 function initUIControls() {
   // Panel collapse toggles
-  $("#toggleLeft").addEventListener("click", () => { 
-    state.ui.leftCollapsed = !state.ui.leftCollapsed; 
-    saveState(); 
-    applyCollapses(); 
+  $("#toggleLeft").addEventListener("click", () => {
+    state.ui.leftCollapsed = !state.ui.leftCollapsed;
+    saveState('ui', state.ui);
+    applyCollapses();
   });
   
-  $("#toggleRight").addEventListener("click", () => { 
-    state.ui.rightCollapsed = !state.ui.rightCollapsed; 
-    saveState(); 
-    applyCollapses(); 
+  $("#toggleRight").addEventListener("click", () => {
+    state.ui.rightCollapsed = !state.ui.rightCollapsed;
+    saveState('ui', state.ui);
+    applyCollapses();
   });
 }
 


### PR DESCRIPTION
## Summary
- update saveState to support partial updates under `inventory/` with timestamp metadata
- save character changes to their specific database paths instead of rewriting all characters
- store UI and item changes separately to avoid clobbering character data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a74888176c832481318b518f5e6cbd