### PR TITLE
Add inventory history viewer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The testing guide provides buttons to help you test specific features, such as:
 
 The application automatically preserves a snapshot of the current character data before each save. Each snapshot is stored in the `inventory/history` node of your Firebase database along with the session ID and a server timestamp. These snapshots let you inspect previous states or restore an earlier inventory.
 
+A simple viewer is available at `history.html` which lists stored snapshots and lets you restore a previous state.
+
 ### Backup and Restore
 
 To work with history snapshots in the browser console:

--- a/history.html
+++ b/history.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Inventory History</title>
+<link rel="stylesheet" href="css/styles.css">
+<style>
+  main { padding: 20px; }
+  .history-entry { display: flex; align-items: center; justify-content: space-between; padding: 8px; border: 1px solid #2a3042; border-radius: 6px; background: #101626; margin-bottom: 6px; }
+  .history-entry time { color: var(--muted); }
+  .history-entry button { padding: 4px 8px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Inventory History</h1>
+</header>
+<main>
+  <div id="historyList">Loading...</div>
+</main>
+<script src="env.js"></script>
+<script type="module" src="js/history-page.js"></script>
+</body>
+</html>

--- a/js/history-page.js
+++ b/js/history-page.js
@@ -1,0 +1,41 @@
+import { fetchHistory, restoreSnapshot } from './history.js';
+
+function createEntry(key, data) {
+  const entry = document.createElement('div');
+  entry.className = 'history-entry';
+
+  const time = document.createElement('time');
+  const date = data.timestamp ? new Date(data.timestamp).toLocaleString() : 'unknown time';
+  time.textContent = `${date} (${data.sessionId || 'unknown'})`;
+  entry.appendChild(time);
+
+  const btn = document.createElement('button');
+  btn.textContent = 'Restore';
+  btn.addEventListener('click', async () => {
+    await restoreSnapshot(key);
+    alert('Snapshot restored');
+  });
+  entry.appendChild(btn);
+
+  return entry;
+}
+
+async function loadHistory() {
+  const container = document.getElementById('historyList');
+  container.textContent = 'Loading...';
+  try {
+    const history = await fetchHistory();
+    container.innerHTML = '';
+    const entries = Object.entries(history).sort((a, b) => (b[1].timestamp || 0) - (a[1].timestamp || 0));
+    if (!entries.length) {
+      container.textContent = 'No history available.';
+      return;
+    }
+    entries.forEach(([key, data]) => container.appendChild(createEntry(key, data)));
+  } catch (err) {
+    container.textContent = 'Failed to load history.';
+    console.error(err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadHistory);


### PR DESCRIPTION
## Summary
- Create `history.html` to display saved inventory snapshots
- Implement `history-page.js` to list and restore snapshots using existing history utilities
- Document new history viewer in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8dc6640f4832497b0b456f161174f