### PR TITLE
Ensure inventory updates create history snapshots

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -79,10 +79,15 @@ async function saveState(path = null, value) {
   if (isSyncing || state.readOnlyMode) return;
 
   if (path) {
-    // If the path is under the inventory node, update it along with the
-    // timestamp/owner metadata so other clients receive the change without
-    // overwriting unrelated characters.
     if (path.startsWith('inventory/')) {
+      // Backup the current state before applying an inventory update
+      push(ref(database, 'inventory/history'), {
+        chars: state.chars,
+        timestamp: serverTimestamp(),
+        sessionId
+      });
+
+      // Update the specific inventory path with metadata
       const inventoryRef = ref(database, 'inventory');
       const updates = {
         [path.replace('inventory/', '')]: value,


### PR DESCRIPTION
## Summary
- Generate history snapshots whenever inventory paths are saved
- Preserve prior state before updating inventory nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9210b298483248cd5b21c61230bee