### PR TITLE
Fix item library search by filtering notes

### DIFF
--- a/js/items.js
+++ b/js/items.js
@@ -345,7 +345,11 @@ function renderItems() {
   
   $("#cancelEditBtn")?.addEventListener("click", toggleEditItemForm);
 
-  const entries = Object.entries(state.items).filter(([id, i]) => !q || i.name.toLowerCase().includes(q));
+  const entries = Object.entries(state.items).filter(([id, i]) => {
+    const nameMatch = i.name?.toLowerCase().includes(q);
+    const notesMatch = i.notes?.toLowerCase().includes(q);
+    return !q || nameMatch || notesMatch;
+  });
   if (entries.length === 0) {
     const div = document.createElement("div");
     div.className = "muted";


### PR DESCRIPTION
## Summary
- Broaden item library search to match both item names and notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef42ea338832488caf5ff8c45b110