### PR TITLE
Hide create item form after saving

### DIFF
--- a/js/items.js
+++ b/js/items.js
@@ -235,7 +235,7 @@ function renderItems() {
 
       if (await addItem(name, slots, notes, hasSubSlots, maxSubSlots, subSlotName)) {
         // Success, hide the form
-        toggleCreateItemForm();
+        hideCreateItemForm();
       } else {
         // Generic failure message
         alert("Failed to add item. Please try again.");
@@ -468,6 +468,14 @@ function toggleCreateItemForm() {
     if (editForm && !editForm.classList.contains("hidden")) {
       editForm.classList.add("hidden");
     }
+  }
+}
+
+function hideCreateItemForm() {
+  const form = $("#createItemForm");
+  if (form) {
+    form.classList.add("hidden");
+    if (state.ui) state.ui.tempItemNotes = "";
   }
 }
 


### PR DESCRIPTION
## Summary
- Hide the create item form after successfully saving a new item
- Add `hideCreateItemForm` helper to explicitly conceal the form and reset draft notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aefad48e208324b7aa18f2e0c625c1