### PR TITLE
Handle localStorage quota exceeded

### DIFF
--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -15,6 +15,7 @@ import {
   runTransaction,
   remove
 } from 'https://www.gstatic.com/firebasejs/10.10.0/firebase-database.js';
+import { safeGet, safeSet } from './storage.js';
 
 // Firebase configuration loaded from environment variables
 const firebaseConfig = {
@@ -32,10 +33,10 @@ const app = initializeApp(firebaseConfig);
 const database = getDatabase(app);
 
 // Generate a unique ID for this user's session if they don't have one
-let sessionId = localStorage.getItem("inventory_session_id");
+let sessionId = safeGet('inventory_session_id');
 if (!sessionId) {
   sessionId = Date.now().toString(36) + Math.random().toString(36).substring(2);
-  localStorage.setItem("inventory_session_id", sessionId);
+  safeSet('inventory_session_id', sessionId);
 }
 
 // Export Firebase modules and initialized instances

--- a/js/state.js
+++ b/js/state.js
@@ -11,6 +11,7 @@ import {
   get,
   remove
 } from './firebase-config.js';
+import { safeGet, safeSet } from './storage.js';
 
 // Initialize state with defaults
 const state = {
@@ -27,10 +28,12 @@ const state = {
 
 // Load state from local storage initially (for quick startup)
 function loadLocalState() {
-  try { 
-    return JSON.parse(localStorage.getItem("inv_external_items_v5")||""); 
-  } catch { 
-    return null; 
+  const raw = safeGet('inv_external_items_v5');
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
   }
 }
 
@@ -83,7 +86,7 @@ function toggleCharSelection(idx) {
   } else {
     arr.push(idx);
   }
-  localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
+  safeSet('inv_external_items_v5', JSON.stringify(state));
 }
 
 function getSelectedCharIndices() {
@@ -120,7 +123,7 @@ async function saveState(path = null, value) {
   removeExpandedFlags();
 
   // Always save to localStorage for quick loading next time
-  localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
+  safeSet('inv_external_items_v5', JSON.stringify(state));
 
   // Don't sync to Firebase if we're currently processing a sync from Firebase
   // or if we're in read-only mode and haven't had user interaction yet
@@ -164,7 +167,7 @@ async function saveState(path = null, value) {
       if (typeof data.lastUpdated === 'number') {
         lastInventoryUpdate = data.lastUpdated;
       }
-      localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
+      safeSet('inv_external_items_v5', JSON.stringify(state));
       const syncEvent = new CustomEvent('state-sync', { detail: { source: 'firebase' } });
       document.dispatchEvent(syncEvent);
       isSyncing = false;
@@ -248,7 +251,7 @@ function initFirebaseSync() {
     }
     
     // Also update localStorage for faster loading next time
-    localStorage.setItem("inv_external_items_v5", JSON.stringify(state));
+      safeSet('inv_external_items_v5', JSON.stringify(state));
     
     // Trigger UI update events
     const syncEvent = new CustomEvent('state-sync', { detail: { source: 'firebase' } });

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,27 @@
+/* ===== Safe Storage Helpers ===== */
+// Provides wrappers around localStorage that guard against quota errors
+// or disabled storage. Each function returns null/false when storage
+// cannot be accessed.
+
+export function safeGet(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (err) {
+    console.warn(`Failed to read ${key} from localStorage:`, err);
+    return null;
+  }
+}
+
+export function safeSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (err) {
+    if (err && err.name === 'QuotaExceededError') {
+      console.warn(`localStorage quota exceeded for ${key}`);
+    } else {
+      console.warn(`Failed to write ${key} to localStorage:`, err);
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add safeGet and safeSet helpers to guard localStorage operations
- replace direct localStorage usage in state and firebase config modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8f0f5514c8324a67c756fd0946e6c