### PR TITLE
Keep inventory section collapses local

### DIFF
--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -1,5 +1,5 @@
 /* ===== Characters Management ===== */
-import { state, saveState, enableWrites } from '../state.js';
+import { state, saveState, saveLocalUiState, enableWrites } from '../state.js';
 import {
   $,
   slotsFromSTR,
@@ -494,7 +494,7 @@ function renderChars() {
           state.ui.smallSackCollapsed[charIndex] = !state.ui.smallSackCollapsed[charIndex];
         }
         
-        saveState('ui', state.ui);
+        saveLocalUiState();
         renderChars();
       });
     });

--- a/js/characters/render.js
+++ b/js/characters/render.js
@@ -475,6 +475,8 @@ function renderChars() {
     notesSection.appendChild(notesArea);
     inv.appendChild(notesSection);
 
+    charEl.appendChild(inv);
+
     // Add event listeners for collapse buttons
     charEl.querySelectorAll('.collapse-btn').forEach(btn => {
       btn.addEventListener('click', (e) => {
@@ -482,7 +484,7 @@ function renderChars() {
         // even if a child element within the button was clicked
         const charIndex = parseInt(e.currentTarget.dataset.char, 10);
         const section = e.currentTarget.dataset.section;
-        
+
         // Toggle the collapsed state
         if (section === 'equipped') {
           state.ui.equippedCollapsed[charIndex] = !state.ui.equippedCollapsed[charIndex];
@@ -493,14 +495,13 @@ function renderChars() {
         } else if (section === 'smallSack') {
           state.ui.smallSackCollapsed[charIndex] = !state.ui.smallSackCollapsed[charIndex];
         }
-        
+
         saveLocalUiState();
         renderChars();
       });
     });
-    
-    charEl.appendChild(inv);
-  wrap.appendChild(charEl);
+
+    wrap.appendChild(charEl);
   });
 }
 

--- a/js/state.js
+++ b/js/state.js
@@ -117,6 +117,12 @@ async function recordHistorySnapshot(limit = 20) {
   }
 }
 
+// Persist state changes to localStorage without syncing to Firebase
+function saveLocalUiState() {
+  removeExpandedFlags();
+  safeSet('inv_external_items_v5', JSON.stringify(state));
+}
+
 // Save state to local storage and Firebase
 async function saveState(path = null, value) {
   // Clean up any UI-only flags before persisting
@@ -265,6 +271,7 @@ function initFirebaseSync() {
 export {
   state,
   saveState,
+  saveLocalUiState,
   initFirebaseSync,
   enableWrites,
   updateReadOnlyIndicator,


### PR DESCRIPTION
## Summary
- add a helper that persists UI-only state to local storage without syncing to Firebase
- update inventory section collapse buttons to use local persistence so they do not affect other viewers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f5502c01fc8324b58392c8f9fcfa7c